### PR TITLE
Add comment to SdpcmHeader struct

### DIFF
--- a/src/structs.rs
+++ b/src/structs.rs
@@ -19,6 +19,7 @@ macro_rules! impl_bytes {
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(C)]
+// SDIO Packet Control Management (SDPCM)
 pub struct SdpcmHeader {
     pub len: u16,
     pub len_inv: u16,


### PR DESCRIPTION
The motivation for adding this comment was that I ended up searching for
the meaning of `SDPCM` and came up empty, and this is my best guess.

----------------------------
This might be incorrect but hopefully someone will be able to provide the correct meaning of `SDPCM`. Perhaps the `C` is for credit, `SDIO Packet and Credit Management`. Any thoughts on this?