### PR TITLE
Add comments about Country Locale Matrix (CLM)

### DIFF
--- a/examples/rpi-pico-w/src/main.rs
+++ b/examples/rpi-pico-w/src/main.rs
@@ -42,7 +42,7 @@ async fn net_task(stack: &'static Stack<cyw43::NetDevice<'static>>) -> ! {
 async fn main(spawner: Spawner, p: Peripherals) {
     info!("Hello World!");
 
-    // Include the WiFi firmware and CLM.
+    // Include the WiFi firmware and Country Locale Matrix (CLM) blobs.
     let fw = include_bytes!("../../../firmware/43439A0.bin");
     let clm = include_bytes!("../../../firmware/43439A0_clm.bin");
 

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -172,6 +172,7 @@ pub const DOWNLOAD_FLAG_BEGIN: u16 = 0x0002;
 pub const DOWNLOAD_FLAG_END: u16 = 0x0004;
 pub const DOWNLOAD_FLAG_HANDLER_VER: u16 = 0x1000;
 
+// Country Locale Matrix (CLM)
 pub const DOWNLOAD_TYPE_CLM: u16 = 2;
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
This commit add comments about what `CLM` stands for.

The motivation of this is that I think it helps understanding the code
for users who are new to the codebase (like me).