### PR TITLE
Add WORD_LENGTH_32 constant

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@ const REG_BUS_STATUS: u32 = 0x8;
 const REG_BUS_FEEDBEAD: u32 = 0x14;
 const REG_BUS_TEST: u32 = 0x18;
 const REG_BUS_RESP_DELAY: u32 = 0x1c;
+const WORD_LENGTH_32: u32 = 0x1;
+const HIGH_SPEED: u32 = 0x10;
 
 // SPI_STATUS_REGISTER bits
 const STATUS_DATA_NOT_AVAILABLE: u32 = 0x00000001;
@@ -570,8 +572,8 @@ where
         let val = self.read32_swapped(REG_BUS_TEST).await;
         assert_eq!(val, TEST_PATTERN);
 
-        // 32bit, little endian.
-        self.write32_swapped(REG_BUS_CTRL, 0x00010031).await;
+        // 32-bit word length, little endian (which is the default endianess).
+        self.write32_swapped(REG_BUS_CTRL, WORD_LENGTH_32 | HIGH_SPEED).await;
 
         let val = self.read32(FUNC_BUS, REG_BUS_FEEDBEAD).await;
         assert_eq!(val, FEEDBEAD);


### PR DESCRIPTION
This commit adds a constant which is intended to be used for setting
the `Word Length` field in the gSPR register (address: 0x0000, bit: 0).

Currently, this field is being set by the following line:
```rust
        // 32bit, little endian.
        self.write32_swapped(REG_BUS_CTRL, 0x00010031).await;
```

Assuming that we are sending these bits using the gSPI write protocol
and using 16-bit word operation in little endian (which I think might
be the default) then the data bytes should be packed like this:
```
  +--+--+--+--+
  |D1|D0|D3|D2|
  +--+--+--+--+

val (hex):   0x00010031
val (bin):   00000000000000010000000000110001
rotated(16): 00000000001100010000000000000001
```

If we split val into bytes and rotated the bits we get:
```
Split into bytes:
   D3      D2        D1       D0
00000000 00000001 00000000 00110001

Rotate 16 and split into bytes:
   D1      D0        D3       D2
00000000 00110001 00000000 00000001
```
Looking at the write procotol it seems to me that the above will
indeed set the `Word Length` to 1 but will also set other values
(but they are all the default values for these fields so there is no
"harm" in doing this):
```
                                  Status enable (1=default)
   D1      D0        D3       D2  ↓
00000000 00110001 00000000 00000001
           ↑↑  ↑↑                 ↑
           ||  |Word Length (1=32-bit)
           ||  |
           ||  Endianess (0=Little)
           ||
           |High-speed mode (1=High speed (default))
           |
           Interrupt polarity (1=high (default))
```

This commit suggests adding the above mentioned constant for setting
the only the word length field.