### PR TITLE
Fix calculation of slice index

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -762,7 +762,7 @@ where
                 let bus = unsafe { &mut *bus };
                 async {
                     bus.write(&[cmd]).await?;
-                    bus.write(&buf[..(total_len + 3 / 4)]).await?;
+                    bus.write(&buf[..(total_len / 4)]).await?;
                     Ok(())
                 }
             })


### PR DESCRIPTION
total_len is already rounded up, so the `+ 3` is not needed.
And even if it was, the calculation should have been `((total_len + 3) / 4)`.

`(total_len + 3 / 4)` is equivalent to `total_len` and can overflow
the slice, leading to a panic which can easily be triggered by sending
large ICMP ECHO packets to the device.