### PR TITLE
Use wrapping_sub in update_credit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -916,7 +916,7 @@ where
     fn update_credit(&mut self, sdpcm_header: &SdpcmHeader) {
         if sdpcm_header.channel_and_flags & 0xf < 3 {
             let mut sdpcm_seq_max = sdpcm_header.bus_data_credit;
-            if sdpcm_seq_max - self.sdpcm_seq > 0x40 {
+            if sdpcm_seq_max.wrapping_sub(self.sdpcm_seq) > 0x40 {
                 sdpcm_seq_max = self.sdpcm_seq + 2;
             }
             self.sdpcm_seq_max = sdpcm_seq_max;


### PR DESCRIPTION
This commit uses wrapping_sub for subtraction in update_credit.

The motivation for this is that currently the rpi-pico-w example panics (at least for me) with the following error:
```console
3.825277 INFO  init done
└─ cyw43::{impl#4}::init::{async_fn#0} @ /embassy/cyw43/src/fmt.rs:138 3.825486 INFO  Downloading CLM...
└─ cyw43::{impl#2}::init::{async_fn#0} @ /embassy/cyw43/src/fmt.rs:138 3.841328 WARN  TX stalled
└─ cyw43::{impl#4}::run::{async_fn#0} @ /embassy/cyw43/src/fmt.rs:151 3.845549 ERROR panicked at 'attempt to subtract with overflow', /embassy/cyw43/src/lib.rs:919:16 └─ panic_probe::print_defmt::print @ .cargo/registry/src/github.com-1ecc6299db9ec823/panic-probe-0.3.0/src/lib.rs:91 
──────────────────────────────────────────────────────────────────────────────── 
stack backtrace:
   0: HardFaultTrampoline
      <exception entry>
   1: lib::inline::__udf
        at ./asm/inline.rs:181:5
   2: __udf
        at ./asm/lib.rs:51:17
   3: cortex_m::asm::udf
        at .cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.7.6/src/asm.rs:43:5
   4: rust_begin_unwind
        at .cargo/registry/src/github.com-1ecc6299db9ec823/panic-probe-0.3.0/src/lib.rs:72:9
   5: core::panicking::panic_fmt
        at rustc/1c7b36d4db582cb47513a6c7176baaec1c3346ab/library/core/src/panicking.rs:142:14
   6: core::panicking::panic
        at /rustc/1c7b36d4db582cb47513a6c7176baaec1c3346ab/library/core/src/panicking.rs:48:5
   7: cyw43::Runner<PWR,SPI>::update_credit
        at /embassy/cyw43/src/lib.rs:919:16
   8: cyw43::Runner<PWR,SPI>::rx
        at /embassy/cyw43/src/lib.rs:808:9
   9: cyw43::Runner<PWR,SPI>::run::{{closure}}
        at /embassy/cyw43/src/lib.rs:727:21
  10: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
        at /rustc/1c7b36d4db582cb47513a6c7176baaec1c3346ab/library/core/src/future/mod.rs:91:19
  11: cyw43_example_rpi_pico_w::__wifi_task_task::{{closure}}
        at src/main.rs:32:17
```