### PR TITLE
Add contants and update comment about ALP

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,9 @@ const BACKPLANE_WINDOW_SIZE: usize = 0x8000;
 const BACKPLANE_ADDRESS_MASK: u32 = 0x7FFF;
 const BACKPLANE_ADDRESS_32BIT_FLAG: u32 = 0x08000;
 const BACKPLANE_MAX_TRANSFER_SIZE: usize = 64;
+// Active Low Power (ALP) clock constants
+const BACKPLANE_ALP_AVAIL_REQ: u8 = 0x08;
+const BACKPLANE_ALP_AVAIL: u8 = 0x40;
 
 // Broadcom AMBA (Advanced Microcontroller Bus Architecture) Interconnect (AI)
 // constants
@@ -603,10 +606,11 @@ where
         // seems to break backplane??? eat the 4-byte delay instead, that's what the vendor drivers do...
         //self.write32(FUNC_BUS, REG_BUS_RESP_DELAY, 0).await;
 
-        // Init ALP (no idea what that stands for) clock
-        self.write8(FUNC_BACKPLANE, REG_BACKPLANE_CHIP_CLOCK_CSR, 0x08).await;
+        // Init ALP (Active Low Power) clock
+        self.write8(FUNC_BACKPLANE, REG_BACKPLANE_CHIP_CLOCK_CSR, BACKPLANE_ALP_AVAIL_REQ)
+            .await;
         info!("waiting for clock...");
-        while self.read8(FUNC_BACKPLANE, REG_BACKPLANE_CHIP_CLOCK_CSR).await & 0x40 == 0 {}
+        while self.read8(FUNC_BACKPLANE, REG_BACKPLANE_CHIP_CLOCK_CSR).await & BACKPLANE_ALP_AVAIL == 0 {}
         info!("clock ok");
 
         let chip_id = self.bp_read16(0x1800_0000).await;


### PR DESCRIPTION
This commit add two constants and updates the comment about ALP.

It was not easy to find the definition of ALP but after searching I found what I believe is the correct definition in section 3.3 "Clocks" in the referenced document below.

>Active Low Power (ALP):
Supplied by an internal or external oscillator. This clock is requested by cores when accessing backplane registers in other cores or when performing minor computations. When an external crystal is used to provide reference clock, ALP clock frequency is determined by the frequency of the external oscillator. A 37.4 MHz reference clock
 is recommended.

Refs:
https://www.infineon.com/dgdl/Infineon-AN214828_Power_Consumption_Measurements-ApplicationNotes-v03_00-EN.pdf?fileId=8ac78c8c7cdc391c017d0d2803a4630d