### PR TITLE
Add comment about bus:txglom iovar

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,6 +291,9 @@ impl<'a> Control<'a> {
 
         info!("Configuring misc stuff...");
 
+        // Disable tx gloming which transfers multiple packets in one request.
+        // 'glom' is short for "conglomerate" which means "gather together into
+        // a compact mass".
         self.set_iovar_u32("bus:txglom", 0).await;
         self.set_iovar_u32("apsta", 1).await;
 


### PR DESCRIPTION
This commit adds a comment to the setting of the iovar `bus:txglom`.

The motivation for this is that I had not heard of 'glom/glomming' before and having a comment might help others that are not familar with the term.