### PR TITLE
Add constants for BDC_VERSION

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -800,7 +800,7 @@ where
         };
 
         let bcd_header = BcdHeader {
-            flags: 0x20,
+            flags: BDC_VERSION << BDC_VERSION_SHIFT,
             priority: 0,
             flags2: 0,
             data_offset: 0,

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -53,6 +53,9 @@ pub struct CdcHeader {
 }
 impl_bytes!(CdcHeader);
 
+pub const BDC_VERSION: u8 = 2;
+pub const BDC_VERSION_SHIFT: u8 = 4;
+
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(C)]


### PR DESCRIPTION
This commit adds two constants intended to be used with the bdc_header.flags field. I believe these are the correct values after looking at following lines in `whd_cdc_bdc.c`:

https://github.com/Infineon/wifi-host-driver/blob/40a7ec2273a950fbf89353d3eac98c5c1c2fd8cd/WiFi_Host_Driver/src/whd_cdc_bdc.c#L34-L35 https://github.com/Infineon/wifi-host-driver/blob/40a7ec2273a950fbf89353d3eac98c5c1c2fd8cd/WiFi_Host_Driver/src/whd_cdc_bdc.c#L447