### PR TITLE
Be able to specify the power management mode at init time.

### DIFF
--- a/examples/rpi-pico-w/src/main.rs
+++ b/examples/rpi-pico-w/src/main.rs
@@ -70,7 +70,7 @@ async fn main(spawner: Spawner) {
 
     spawner.spawn(wifi_task(runner)).unwrap();
 
-    control.init(clm).await;
+    control.init(clm, cyw43::PowerManagementMode::PowerSave).await;
 
     //control.join_open(env!("WIFI_NETWORK")).await;
     control.join_wpa2(env!("WIFI_NETWORK"), env!("WIFI_PASSWORD")).await;

--- a/examples/rpi-pico-w/src/main.rs
+++ b/examples/rpi-pico-w/src/main.rs
@@ -70,7 +70,10 @@ async fn main(spawner: Spawner) {
 
     spawner.spawn(wifi_task(runner)).unwrap();
 
-    control.init(clm, cyw43::PowerManagementMode::PowerSave).await;
+    control.init(clm).await;
+    control
+        .set_power_management(cyw43::PowerManagementMode::PowerSave)
+        .await;
 
     //control.join_open(env!("WIFI_NETWORK")).await;
     control.join_wpa2(env!("WIFI_NETWORK"), env!("WIFI_PASSWORD")).await;


### PR DESCRIPTION
This adds the ability to specify the power management mode in `control.init()` call.

Also, it actually fixes the pm mode setup, where an incorrect command was sent to ioctl (`0x86` as opposed to the correct `86`), see https://github.com/georgerobotics/cyw43-driver/blob/195dfcc10bb6f379e3dea45147590db2203d3c7b/src/cyw43_ll.c#L247.

In my simple setup (listening to the tcp socket on the rpi pico w), just entering any power saving mode lowers the power consumption by a third when there is no traffic.