### PR TITLE
Fixed length for wlan_read.

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -48,11 +48,12 @@ where
         assert_eq!(val, TEST_PATTERN);
     }
 
-    pub async fn wlan_read(&mut self, buf: &mut [u32]) {
-        let cmd = cmd_word(READ, INC_ADDR, FUNC_WLAN, 0, buf.len() as u32 * 4);
+    pub async fn wlan_read(&mut self, buf: &mut [u32], len_in_u8: u32) {
+        let cmd = cmd_word(READ, INC_ADDR, FUNC_WLAN, 0, len_in_u8);
+        let len_in_u32 = (len_in_u8 as usize + 3) / 4;
         transaction!(&mut self.spi, |bus| async {
             bus.write(&[cmd]).await?;
-            bus.read(buf).await?;
+            bus.read(&mut buf[..len_in_u32]).await?;
             Ok(())
         })
         .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -687,7 +687,7 @@ where
                 if status & STATUS_F2_PKT_AVAILABLE != 0 {
                     let len = (status & STATUS_F2_PKT_LEN_MASK) >> STATUS_F2_PKT_LEN_SHIFT;
 
-                    self.bus.wlan_read(&mut buf[..(len as usize + 3) / 4]).await;
+                    self.bus.wlan_read(&mut buf, len).await;
                     trace!("rx {:02x}", &slice8_mut(&mut buf)[..(len as usize).min(48)]);
                     self.rx(&slice8_mut(&mut buf)[..len as usize]);
                 }


### PR DESCRIPTION
The length provided in command word for FUNC_WLAN READ, should describe the actual bytes requested, not the size of the buffer which is sized in u32.