### PR TITLE
Use PIO for SPI communication in Pico W example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,4 @@ cortex-m-rt = "0.7.0"
 futures = { version = "0.3.17", default-features = false, features = ["async-await", "cfg-target-has-atomic", "unstable"] }
 
 embedded-hal-1 = { package = "embedded-hal", version = "1.0.0-alpha.9" }
-embedded-hal-async = { version = "0.2.0-alpha.0" }
 num_enum = { version = "0.5.7", default-features = false }

--- a/examples/rpi-pico-w/Cargo.toml
+++ b/examples/rpi-pico-w/Cargo.toml
@@ -47,8 +47,6 @@ futures = { version = "0.3.17", default-features = false, features = [
 pio-proc = "0.2"
 pio = "0.2.1"
 
-embedded-hal-1 = { package = "embedded-hal", version = "1.0.0-alpha.9" }
-embedded-hal-async = { version = "0.2.0-alpha.0" }
 embedded-io = { version = "0.4.0", features = ["async", "defmt"] }
 heapless = "0.7.15"
 

--- a/examples/rpi-pico-w/Cargo.toml
+++ b/examples/rpi-pico-w/Cargo.toml
@@ -6,30 +6,10 @@ edition = "2021"
 
 [dependencies]
 cyw43 = { path = "../../", features = ["defmt", "firmware-logs"] }
-embassy-executor = { version = "0.1.0", features = [
-    "defmt",
-    "integrated-timers",
-] }
-embassy-time = { version = "0.1.0", features = [
-    "defmt",
-    "defmt-timestamp-uptime",
-] }
-embassy-rp = { version = "0.1.0", features = [
-    "defmt",
-    "unstable-traits",
-    "nightly",
-    "unstable-pac",
-    "pio",
-    "time-driver",
-] }
-embassy-net = { version = "0.1.0", features = [
-    "defmt",
-    "tcp",
-    "dhcpv4",
-    "medium-ethernet",
-    "unstable-traits",
-    "nightly",
-] }
+embassy-executor = { version = "0.1.0",  features = ["defmt", "integrated-timers"] }
+embassy-time = { version = "0.1.0",  features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-rp = { version = "0.1.0",  features = ["defmt", "unstable-traits", "nightly", "unstable-pac", "time-driver", "pio"] }
+embassy-net = { version = "0.1.0", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", "unstable-traits", "nightly"] }
 atomic-polyfill = "0.1.5"
 static_cell = "1.0"
 
@@ -39,11 +19,7 @@ panic-probe = { version = "0.3", features = ["print-defmt"] }
 
 cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
-futures = { version = "0.3.17", default-features = false, features = [
-    "async-await",
-    "cfg-target-has-atomic",
-    "unstable",
-] }
+futures = { version = "0.3.17", default-features = false, features = ["async-await", "cfg-target-has-atomic", "unstable"] }
 pio-proc = "0.2"
 pio = "0.2.1"
 

--- a/examples/rpi-pico-w/Cargo.toml
+++ b/examples/rpi-pico-w/Cargo.toml
@@ -5,11 +5,31 @@ edition = "2021"
 
 
 [dependencies]
-cyw43 = { path = "../../", features = ["defmt", "firmware-logs"]}
-embassy-executor = { version = "0.1.0",  features = ["defmt", "integrated-timers"] }
-embassy-time = { version = "0.1.0",  features = ["defmt", "defmt-timestamp-uptime"] }
-embassy-rp = { version = "0.1.0",  features = ["defmt", "unstable-traits", "nightly", "unstable-pac", "time-driver"] }
-embassy-net = { version = "0.1.0", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", "unstable-traits", "nightly"] }
+cyw43 = { path = "../../", features = ["defmt", "firmware-logs"] }
+embassy-executor = { version = "0.1.0", features = [
+    "defmt",
+    "integrated-timers",
+] }
+embassy-time = { version = "0.1.0", features = [
+    "defmt",
+    "defmt-timestamp-uptime",
+] }
+embassy-rp = { version = "0.1.0", features = [
+    "defmt",
+    "unstable-traits",
+    "nightly",
+    "unstable-pac",
+    "pio",
+    "time-driver",
+] }
+embassy-net = { version = "0.1.0", features = [
+    "defmt",
+    "tcp",
+    "dhcpv4",
+    "medium-ethernet",
+    "unstable-traits",
+    "nightly",
+] }
 atomic-polyfill = "0.1.5"
 static_cell = "1.0"
 
@@ -17,9 +37,15 @@ defmt = "0.3"
 defmt-rtt = "0.3"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 
-cortex-m = { version = "0.7.6", features = ["critical-section-single-core"]}
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.0"
-futures = { version = "0.3.17", default-features = false, features = ["async-await", "cfg-target-has-atomic", "unstable"] }
+futures = { version = "0.3.17", default-features = false, features = [
+    "async-await",
+    "cfg-target-has-atomic",
+    "unstable",
+] }
+pio-proc = "0.2"
+pio = "0.2.1"
 
 embedded-hal-1 = { package = "embedded-hal", version = "1.0.0-alpha.9" }
 embedded-hal-async = { version = "0.2.0-alpha.0" }

--- a/examples/rpi-pico-w/build.rs
+++ b/examples/rpi-pico-w/build.rs
@@ -14,23 +14,23 @@ use std::io::Write;
 use std::path::PathBuf;
 
 fn main() {
-    // // Put `memory.x` in our output directory and ensure it's
-    // // on the linker search path.
-    // let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-    // File::create(out.join("memory.x"))
-    //     .unwrap()
-    //     .write_all(include_bytes!("memory.x"))
-    //     .unwrap();
-    // println!("cargo:rustc-link-search={}", out.display());
+    // Put `memory.x` in our output directory and ensure it's
+    // on the linker search path.
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    File::create(out.join("memory.x"))
+        .unwrap()
+        .write_all(include_bytes!("memory.x"))
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
 
-    // // By default, Cargo will re-run a build script whenever
-    // // any file in the project changes. By specifying `memory.x`
-    // // here, we ensure the build script is only re-run when
-    // // `memory.x` is changed.
-    // println!("cargo:rerun-if-changed=memory.x");
+    // By default, Cargo will re-run a build script whenever
+    // any file in the project changes. By specifying `memory.x`
+    // here, we ensure the build script is only re-run when
+    // `memory.x` is changed.
+    println!("cargo:rerun-if-changed=memory.x");
 
-    // println!("cargo:rustc-link-arg-bins=--nmagic");
-    // println!("cargo:rustc-link-arg-bins=-Tlink.x");
-    // println!("cargo:rustc-link-arg-bins=-Tlink-rp.x");
-    // println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+    println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    println!("cargo:rustc-link-arg-bins=-Tlink-rp.x");
+    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
 }

--- a/examples/rpi-pico-w/build.rs
+++ b/examples/rpi-pico-w/build.rs
@@ -14,23 +14,23 @@ use std::io::Write;
 use std::path::PathBuf;
 
 fn main() {
-    // Put `memory.x` in our output directory and ensure it's
-    // on the linker search path.
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-    File::create(out.join("memory.x"))
-        .unwrap()
-        .write_all(include_bytes!("memory.x"))
-        .unwrap();
-    println!("cargo:rustc-link-search={}", out.display());
+    // // Put `memory.x` in our output directory and ensure it's
+    // // on the linker search path.
+    // let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    // File::create(out.join("memory.x"))
+    //     .unwrap()
+    //     .write_all(include_bytes!("memory.x"))
+    //     .unwrap();
+    // println!("cargo:rustc-link-search={}", out.display());
 
-    // By default, Cargo will re-run a build script whenever
-    // any file in the project changes. By specifying `memory.x`
-    // here, we ensure the build script is only re-run when
-    // `memory.x` is changed.
-    println!("cargo:rerun-if-changed=memory.x");
+    // // By default, Cargo will re-run a build script whenever
+    // // any file in the project changes. By specifying `memory.x`
+    // // here, we ensure the build script is only re-run when
+    // // `memory.x` is changed.
+    // println!("cargo:rerun-if-changed=memory.x");
 
-    println!("cargo:rustc-link-arg-bins=--nmagic");
-    println!("cargo:rustc-link-arg-bins=-Tlink.x");
-    println!("cargo:rustc-link-arg-bins=-Tlink-rp.x");
-    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+    // println!("cargo:rustc-link-arg-bins=--nmagic");
+    // println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    // println!("cargo:rustc-link-arg-bins=-Tlink-rp.x");
+    // println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
 }

--- a/examples/rpi-pico-w/src/main.rs
+++ b/examples/rpi-pico-w/src/main.rs
@@ -161,6 +161,17 @@ impl ErrorType for MySpi {
     type Error = Infallible;
 }
 
+impl cyw43::SpiBusCyw43<u32> for MySpi {
+    async fn cmd_write<'a>(&'a mut self, write: &'a [u32]) -> Result<(), Self::Error> {
+        self.write(write).await
+    }
+
+    async fn cmd_read<'a>(&'a mut self, write: &'a [u32], read: &'a mut [u32]) -> Result<(), Self::Error> {
+        self.write(write).await?;
+        self.read(read).await
+    }
+}
+
 impl SpiBusFlush for MySpi {
     async fn flush(&mut self) -> Result<(), Self::Error> {
         Ok(())

--- a/examples/rpi-pico-w/src/pio.rs
+++ b/examples/rpi-pico-w/src/pio.rs
@@ -1,0 +1,190 @@
+use core::slice;
+
+use cyw43::SpiBusCyw43;
+use embassy_rp::dma::Channel;
+use embassy_rp::gpio::{Pin, Pull};
+use embassy_rp::pio::{PioStateMachine, ShiftDirection};
+use embassy_rp::relocate::RelocatedProgram;
+use embassy_rp::{pio_instr_util, Peripheral};
+use embedded_hal_1::spi::ErrorType;
+use embedded_hal_async::spi::SpiBusFlush;
+use pio::Wrap;
+use pio_proc::pio_asm;
+
+pub struct PioSpi<SM, DMA> {
+    // cs: Output<'static, AnyPin>,
+    sm: SM,
+    dma: DMA,
+    wrap_target: u8,
+}
+
+impl<SM, DMA> PioSpi<SM, DMA>
+where
+    SM: PioStateMachine,
+    DMA: Channel,
+{
+    pub fn new<DIO, CLK>(
+        mut sm: SM,
+        // cs: AnyPin,
+        dio: DIO,
+        clk: CLK,
+        dma: DMA,
+    ) -> Self
+    where
+        DIO: Pin,
+        CLK: Pin,
+    {
+        let program = pio_asm!(
+            ".side_set 1"
+            // "set pindirs, 1 side 0"
+            // "set pins, 0    side 0"
+            ".wrap_target"
+            "lp:",
+            "out pins, 1    side 0"
+            "jmp x-- lp     side 1"
+            "set pindirs, 0 side 0"
+            // "nop            side 1"
+            "lp2:"
+            "in pins, 1     side 0"
+            "jmp y-- lp2    side 1"
+            ".wrap"
+        );
+
+        let relocated = RelocatedProgram::new(&program.program);
+
+        let mut pin_io = sm.make_pio_pin(dio);
+        pin_io.set_pull(Pull::Down);
+        pin_io.set_schmitt(true);
+        let pin_clk = sm.make_pio_pin(clk);
+
+        sm.write_instr(relocated.origin() as usize, relocated.code());
+
+        // 16 Mhz
+        sm.set_clkdiv(0x07d0);
+
+        // 8Mhz
+        sm.set_clkdiv(0x0a_00);
+
+        // 1Mhz
+        // sm.set_clkdiv(0x7d_00);
+
+        // slowest possible
+        // sm.set_clkdiv(0xffff_00);
+
+        sm.set_autopull(true);
+        // sm.set_pull_threshold(32);
+        sm.set_autopush(true);
+        // sm.set_push_threshold(32);
+
+        sm.set_out_pins(&[&pin_io]);
+        sm.set_in_base_pin(&pin_io);
+
+        sm.set_set_pins(&[&pin_clk]);
+        pio_instr_util::set_pindir(&mut sm, 0b1);
+        sm.set_set_pins(&[&pin_io]);
+        pio_instr_util::set_pindir(&mut sm, 0b1);
+
+        sm.set_sideset_base_pin(&pin_clk);
+        sm.set_sideset_count(1);
+
+        sm.set_out_shift_dir(ShiftDirection::Left);
+        sm.set_in_shift_dir(ShiftDirection::Left);
+
+        let Wrap { source, target } = relocated.wrap();
+        sm.set_wrap(source, target);
+
+        // pull low for startup
+        pio_instr_util::set_pin(&mut sm, 0);
+
+        Self {
+            // cs: Output::new(cs, Level::High),
+            sm,
+            dma,
+            wrap_target: target,
+        }
+    }
+
+    pub async fn write(&mut self, write: &[u32]) {
+        let write_bits = write.len() * 32 - 1;
+        let read_bits = 31;
+
+        defmt::trace!("write={} read={}", write_bits, read_bits);
+
+        let mut dma = Peripheral::into_ref(&mut self.dma);
+        pio_instr_util::set_x(&mut self.sm, write_bits as u32);
+        pio_instr_util::set_y(&mut self.sm, read_bits as u32);
+        pio_instr_util::set_pindir(&mut self.sm, 0b1);
+        pio_instr_util::exec_jmp(&mut self.sm, self.wrap_target);
+
+        self.sm.set_enable(true);
+
+        self.sm.dma_push(dma.reborrow(), write).await;
+
+        let mut status = 0;
+        self.sm.dma_pull(dma, slice::from_mut(&mut status)).await;
+        defmt::trace!("{:#08x}", status);
+
+        self.sm.set_enable(false);
+    }
+
+    pub async fn cmd_read(&mut self, cmd: u32, read: &mut [u32]) {
+        let write_bits = 31;
+        let read_bits = read.len() * 32 - 1;
+
+        defmt::trace!("write={} read={}", write_bits, read_bits);
+
+        let mut dma = Peripheral::into_ref(&mut self.dma);
+        pio_instr_util::set_y(&mut self.sm, read_bits as u32);
+        pio_instr_util::set_x(&mut self.sm, write_bits as u32);
+        pio_instr_util::set_pindir(&mut self.sm, 0b1);
+        pio_instr_util::exec_jmp(&mut self.sm, self.wrap_target);
+        // self.cs.set_low();
+        self.sm.set_enable(true);
+
+        self.sm.dma_push(dma.reborrow(), slice::from_ref(&cmd)).await;
+        self.sm.dma_pull(dma, read).await;
+
+        self.sm.set_enable(false);
+    }
+}
+
+#[derive(Debug)]
+pub enum PioError {}
+
+impl embedded_hal_async::spi::Error for PioError {
+    fn kind(&self) -> embedded_hal_1::spi::ErrorKind {
+        embedded_hal_1::spi::ErrorKind::Other
+    }
+}
+
+impl<SM, DMA> ErrorType for PioSpi<SM, DMA>
+where
+    SM: PioStateMachine,
+{
+    type Error = PioError;
+}
+
+impl<SM, DMA> SpiBusFlush for PioSpi<SM, DMA>
+where
+    SM: PioStateMachine,
+{
+    async fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl<SM, DMA> SpiBusCyw43<u32> for PioSpi<SM, DMA>
+where
+    SM: PioStateMachine,
+    DMA: Channel,
+{
+    async fn cmd_write<'a>(&'a mut self, write: &'a [u32]) -> Result<(), Self::Error> {
+        self.write(write).await;
+        Ok(())
+    }
+
+    async fn cmd_read<'a>(&'a mut self, write: &'a [u32], read: &'a mut [u32]) -> Result<(), Self::Error> {
+        self.cmd_read(write[0], read).await;
+        Ok(())
+    }
+}

--- a/examples/rpi-pico-w/src/pio.rs
+++ b/examples/rpi-pico-w/src/pio.rs
@@ -155,13 +155,13 @@ where
     SM: PioStateMachine,
     DMA: Channel,
 {
-    async fn cmd_write(&mut self, write: & [u32]) {
+    async fn cmd_write(&mut self, write: &[u32]) {
         self.cs.set_low();
         self.write(write).await;
         self.cs.set_high();
     }
 
-    async fn cmd_read(&mut self, write: u32, read: & mut [u32]) {
+    async fn cmd_read(&mut self, write: u32, read: &mut [u32]) {
         self.cs.set_low();
         self.cmd_read(write, read).await;
         self.cs.set_high();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # Before upgrading check that everything is available on all tier1 targets here:
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
-channel = "nightly-2022-11-22"
+channel = "nightly-2023-03-19"
 components = [ "rust-src", "rustfmt" ]
 targets = [
     "thumbv6m-none-eabi",

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -3,7 +3,7 @@ use core::slice;
 use embassy_time::{Duration, Timer};
 use embedded_hal_1::digital::OutputPin;
 use embedded_hal_1::spi::ErrorType;
-use embedded_hal_async::spi::{transaction, SpiBusRead, SpiBusWrite, SpiDevice};
+use embedded_hal_async::spi::{transaction, SpiDevice};
 
 use crate::consts::*;
 

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -55,32 +55,24 @@ where
         {}
 
         self.write32_swapped(REG_BUS_TEST_RW, TEST_PATTERN).await;
-        let val = self
-            .read32_swapped(REG_BUS_TEST_RW)
-            .inspect(|v| defmt::trace!("{:#x}", v))
-            .await;
+        let val = self.read32_swapped(REG_BUS_TEST_RW).await;
+        defmt::trace!("{:#x}", val);
         assert_eq!(val, TEST_PATTERN);
 
-        self.read32_swapped(REG_BUS_CTRL)
-            .inspect(|v| defmt::trace!("{:#010b}", (v & 0xff)))
-            .await;
+        let val = self.read32_swapped(REG_BUS_CTRL).await;
+        defmt::trace!("{:#010b}", (val & 0xff));
 
         // 32-bit word length, little endian (which is the default endianess).
         self.write32_swapped(REG_BUS_CTRL, WORD_LENGTH_32 | HIGH_SPEED).await;
 
-        self.read8(FUNC_BUS, REG_BUS_CTRL)
-            .inspect(|v| defmt::trace!("{:#b}", v))
-            .await;
+        let val = self.read8(FUNC_BUS, REG_BUS_CTRL).await;
+        defmt::trace!("{:#b}", val);
 
-        let val = self
-            .read32(FUNC_BUS, REG_BUS_TEST_RO)
-            .inspect(|v| defmt::trace!("{:#x}", v))
-            .await;
+        let val = self.read32(FUNC_BUS, REG_BUS_TEST_RO).await;
+        defmt::trace!("{:#x}", val);
         assert_eq!(val, FEEDBEAD);
-        let val = self
-            .read32(FUNC_BUS, REG_BUS_TEST_RW)
-            .inspect(|v| defmt::trace!("{:#x}", v))
-            .await;
+        let val = self.read32(FUNC_BUS, REG_BUS_TEST_RW).await;
+        defmt::trace!("{:#x}", val);
         assert_eq!(val, TEST_PATTERN);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ use embassy_futures::yield_now;
 use embassy_net_driver_channel as ch;
 use embassy_time::{block_for, Duration, Timer};
 use embedded_hal_1::digital::OutputPin;
-use embedded_hal_async::spi::{SpiBusRead, SpiBusWrite, SpiDevice};
+use embedded_hal_async::spi::SpiDevice;
 
 use crate::bus::Bus;
 pub use crate::bus::SpiBusCyw43;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait, concat_bytes)]
+#![allow(incomplete_features)]
+#![feature(async_fn_in_trait, type_alias_impl_trait, concat_bytes)]
 #![deny(unused_must_use)]
 
 // This mod MUST go first, so that the others see its macros.
@@ -24,6 +25,7 @@ use embedded_hal_1::digital::OutputPin;
 use embedded_hal_async::spi::{SpiBusRead, SpiBusWrite, SpiDevice};
 
 use crate::bus::Bus;
+pub use crate::bus::SpiBusCyw43;
 use crate::consts::*;
 use crate::events::Event;
 use crate::structs::*;
@@ -512,7 +514,7 @@ pub async fn new<'a, PWR, SPI>(
 where
     PWR: OutputPin,
     SPI: SpiDevice,
-    SPI::Bus: SpiBusRead<u32> + SpiBusWrite<u32>,
+    SPI::Bus: SpiBusCyw43<u32>,
 {
     let (ch_runner, device) = ch::new(&mut state.ch, [0; 6]);
     let state_ch = ch_runner.state_runner();
@@ -551,7 +553,7 @@ impl<'a, PWR, SPI> Runner<'a, PWR, SPI>
 where
     PWR: OutputPin,
     SPI: SpiDevice,
-    SPI::Bus: SpiBusRead<u32> + SpiBusWrite<u32>,
+    SPI::Bus: SpiBusCyw43<u32>,
 {
     async fn init(&mut self, firmware: &[u8]) {
         self.bus.init().await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@ use embassy_futures::yield_now;
 use embassy_net_driver_channel as ch;
 use embassy_time::{block_for, Duration, Timer};
 use embedded_hal_1::digital::OutputPin;
-use embedded_hal_async::spi::SpiDevice;
 
 use crate::bus::Bus;
 pub use crate::bus::SpiBusCyw43;
@@ -513,8 +512,7 @@ pub async fn new<'a, PWR, SPI>(
 ) -> (NetDriver<'a>, Control<'a>, Runner<'a, PWR, SPI>)
 where
     PWR: OutputPin,
-    SPI: SpiDevice,
-    SPI::Bus: SpiBusCyw43<u32>,
+    SPI: SpiBusCyw43,
 {
     let (ch_runner, device) = ch::new(&mut state.ch, [0; 6]);
     let state_ch = ch_runner.state_runner();
@@ -552,8 +550,7 @@ where
 impl<'a, PWR, SPI> Runner<'a, PWR, SPI>
 where
     PWR: OutputPin,
-    SPI: SpiDevice,
-    SPI::Bus: SpiBusCyw43<u32>,
+    SPI: SpiBusCyw43,
 {
     async fn init(&mut self, firmware: &[u8]) {
         self.bus.init().await;


### PR DESCRIPTION
This PR adds an SPI implementation using a Pio to the Pico W example.

The pio program is based on the pico-sdk with minor changes.

For the pio program itself, the pico sets the `x` and `y` registers before starting the execution. Then the program writes `x+1` bits to the bus and reads `y+1` bits from the bus. Due to autopush and -pull it only takes two cycles per bit. The dio pin is accessed by the `in` and `out` instructions. Clk is controlled by the side-set mechanism.

The pio ist set to 16Mhz for now. The bus does not seem to respond with the pio set to 32Mhz. If I read the data sheet correctly, up to 50Mhz bus clock should be supported, so mabye there is additional settings for that somewhere.

 The first commits introduces a new trait `SpiBusCyw43` to the cyw43 crate. The pio program wants to know the amount of bits to read and write from the start of the transfer. This allows the pio to run continuously for a single transfer without halting it when switching from writing to reading. So splitting the pio operations in separate `read` and `write` calls didn't seem possible to me. Creating a new trait for the bus that supports exactly the kind of communication we need seemed like the best option for now. 

I'm submitting this a draft for now. I'm sure there is some cleanup to do. I'm happy to take feedback on the approach as this is my first time working with embassy and the pico w.
