### PR TITLE
Add from_utf8 for a clearer example

### DIFF
--- a/examples/rpi-pico-w/src/main.rs
+++ b/examples/rpi-pico-w/src/main.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![no_std] 
 #![no_main]
 #![feature(type_alias_impl_trait)]
 #![feature(async_fn_in_trait)]
@@ -18,8 +18,7 @@ use embedded_io::asynch::Write;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 
-use heapless::String;
-
+use core::str::from_utf8;
 
 macro_rules! singleton {
     ($val:expr) => {{
@@ -132,7 +131,7 @@ async fn main(spawner: Spawner) {
                 }
             };
 
-            info!("rxd {}", asciify(&buf[..n]));
+            info!("rxd {}", from_utf8(&buf[..n]).unwrap());
 
 
             match socket.write_all(&buf[..n]).await {
@@ -217,8 +216,4 @@ impl SpiBusWrite<u32> for MySpi {
         self.dio.set_as_input();
         Ok(())
     }
-}
-
-fn asciify(buf: &[u8],) -> String<4096> {
-    buf.into_iter().map(|c| *c as char).into_iter().collect()
 }

--- a/examples/rpi-pico-w/src/main.rs
+++ b/examples/rpi-pico-w/src/main.rs
@@ -18,6 +18,9 @@ use embedded_io::asynch::Write;
 use static_cell::StaticCell;
 use {defmt_rtt as _, panic_probe as _};
 
+use heapless::String;
+
+
 macro_rules! singleton {
     ($val:expr) => {{
         type T = impl Sized;
@@ -129,7 +132,8 @@ async fn main(spawner: Spawner) {
                 }
             };
 
-            info!("rxd {:02x}", &buf[..n]);
+            info!("rxd {}", asciify(&buf[..n]));
+
 
             match socket.write_all(&buf[..n]).await {
                 Ok(()) => {}
@@ -213,4 +217,8 @@ impl SpiBusWrite<u32> for MySpi {
         self.dio.set_as_input();
         Ok(())
     }
+}
+
+fn asciify(buf: &[u8],) -> String<4096> {
+    buf.into_iter().map(|c| *c as char).into_iter().collect()
 }


### PR DESCRIPTION
Adding this function makes displaying the data received more clear for the example code.

### Before:
```
14.568296 INFO Received connection from Some(192.168.0.253:56148)
└─ src/main.rs:115
17.212172 INFO rxd [48, 65, 6c, 6c, 6f, 20, 77, 6f, 72, 6c, 64, 21, 0a]
└─ src/main.rs:130
21.009293 WARN read EOF
└─ src/main.rs:120
```

### After
```
550.665500 INFO Listening on TCP1234...
└─ src/main.rs:109
556.245512 INFO Received connection from Some(192.168.0.253:58000)
└─ src/main.rs:115
559.192893 INFO rxd Hello world!

└─ src/main.rs:130
560.626595 WARN read EOF
```