### PR TITLE
add event handling to join

### DIFF
--- a/examples/rpi-pico-w/src/main.rs
+++ b/examples/rpi-pico-w/src/main.rs
@@ -70,15 +70,10 @@ async fn main(spawner: Spawner) {
     let state = singleton!(cyw43::State::new());
     let (net_device, mut control, runner) = cyw43::new(state, pwr, spi, fw).await;
 
-    spawner.spawn(wifi_task(runner)).unwrap();
-
     control.init(clm).await;
     control
         .set_power_management(cyw43::PowerManagementMode::PowerSave)
         .await;
-
-    //control.join_open(env!("WIFI_NETWORK")).await;
-    control.join_wpa2(env!("WIFI_NETWORK"), env!("WIFI_PASSWORD")).await;
 
     let config = Config::Dhcp(Default::default());
     //let config = embassy_net::Config::Static(embassy_net::Config {
@@ -98,7 +93,11 @@ async fn main(spawner: Spawner) {
         seed
     ));
 
+    unwrap!(spawner.spawn(wifi_task(runner)));
     unwrap!(spawner.spawn(net_task(stack)));
+
+    //control.join_open(env!("WIFI_NETWORK")).await;
+    control.join_wpa2(env!("WIFI_NETWORK"), env!("WIFI_PASSWORD")).await;
 
     // And now we can use it!
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -3,6 +3,9 @@
 
 use core::num;
 
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::pubsub::{PubSubChannel, Publisher, Subscriber};
+
 #[derive(Clone, Copy, PartialEq, Eq, num_enum::FromPrimitive)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
@@ -279,4 +282,15 @@ pub enum Event {
     MGMT_FRAME_TXSTATUS = 189,
     /// highest val + 1 for range checking
     LAST = 190,
+}
+
+pub type EventQueue = PubSubChannel<CriticalSectionRawMutex, EventStatus, 2, 1, 1>;
+pub type EventPublisher<'a> = Publisher<'a, CriticalSectionRawMutex, EventStatus, 2, 1, 1>;
+pub type EventSubscriber<'a> = Subscriber<'a, CriticalSectionRawMutex, EventStatus, 2, 1, 1>;
+
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct EventStatus {
+    pub event_type: Event,
+    pub status: u32,
 }


### PR DESCRIPTION
The join function should wait for the actual join event that happens some time after the ioctl. 

I had some spurious failures with AUTH events when restarting the device so this also has the benefit that we can retry the join, if it goes wrong.