### PR TITLE
Use IRQ instead of polling the status register

### DIFF
--- a/examples/rpi-pico-w/src/main.rs
+++ b/examples/rpi-pico-w/src/main.rs
@@ -227,4 +227,10 @@ impl cyw43::SpiBusCyw43 for MySpi {
         self.read(read).await;
         self.cs.set_high();
     }
+
+    async fn wait_for_event(&mut self) {}
+
+    fn clear_event(&mut self) {}
+
+    
 }

--- a/examples/rpi-pico-w/src/main.rs
+++ b/examples/rpi-pico-w/src/main.rs
@@ -227,10 +227,4 @@ impl cyw43::SpiBusCyw43 for MySpi {
         self.read(read).await;
         self.cs.set_high();
     }
-
-    async fn wait_for_event(&mut self) {}
-
-    fn clear_event(&mut self) {}
-
-    
 }

--- a/examples/rpi-pico-w/src/pio.rs
+++ b/examples/rpi-pico-w/src/pio.rs
@@ -170,9 +170,6 @@ where
 
     async fn wait_for_event(&mut self) {
         self.sm.wait_irq(0).await;
-    }
-
-    fn clear_event(&mut self) {
         self.sm.clear_irq(0);
     }
 }

--- a/examples/rpi-pico-w/src/pio.rs
+++ b/examples/rpi-pico-w/src/pio.rs
@@ -41,6 +41,9 @@ where
             "in pins, 1     side 1"
             "jmp y-- lp2    side 0"
 
+            "wait 1 pin 0   side 0"
+            "irq 0          side 0"
+
             ".wrap"
         );
 
@@ -106,6 +109,7 @@ where
     }
 
     pub async fn write(&mut self, write: &[u32]) {
+        self.sm.set_enable(false);
         let write_bits = write.len() * 32 - 1;
         let read_bits = 31;
 
@@ -124,11 +128,10 @@ where
         let mut status = 0;
         self.sm.dma_pull(dma, slice::from_mut(&mut status)).await;
         defmt::trace!("{:#08x}", status);
-
-        self.sm.set_enable(false);
     }
 
     pub async fn cmd_read(&mut self, cmd: u32, read: &mut [u32]) {
+        self.sm.set_enable(false);
         let write_bits = 31;
         let read_bits = read.len() * 32 - 1;
 
@@ -144,8 +147,6 @@ where
 
         self.sm.dma_push(dma.reborrow(), slice::from_ref(&cmd)).await;
         self.sm.dma_pull(dma, read).await;
-
-        self.sm.set_enable(false);
     }
 }
 
@@ -165,5 +166,13 @@ where
         self.cs.set_low();
         self.cmd_read(write, read).await;
         self.cs.set_high();
+    }
+
+    async fn wait_for_event(&mut self) {
+        self.sm.wait_irq(0).await;
+    }
+
+    fn clear_event(&mut self) {
+        self.sm.clear_irq(0);
     }
 }

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -1,5 +1,6 @@
 use core::slice;
 
+use embassy_futures::yield_now;
 use embassy_time::{Duration, Timer};
 use embedded_hal_1::digital::OutputPin;
 use futures::FutureExt;
@@ -20,8 +21,11 @@ pub trait SpiBusCyw43 {
     /// Callers that want to read `n` word from the backplane, have to provide a slice that is `n+1` words long.
     async fn cmd_read(&mut self, write: u32, read: &mut [u32]);
 
-    async fn wait_for_event(&mut self);
-    fn clear_event(&mut self);
+    /// Wait for events from the Device. A typical implementation would wait for the IRQ pin to be high.
+    /// The default implementation always reports ready, resulting in active polling of the device.
+    async fn wait_for_event(&mut self) {
+        yield_now().await;
+    }
 }
 
 pub(crate) struct Bus<PWR, SPI> {
@@ -304,10 +308,6 @@ where
 
     pub async fn wait_for_event(&mut self) {
         self.spi.wait_for_event().await;
-    }
-
-    pub fn clear_event(&mut self) {
-        self.spi.clear_event();
     }
 }
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -14,6 +14,8 @@ pub(crate) const REG_BUS_TEST_RW: u32 = 0x18;
 pub(crate) const REG_BUS_RESP_DELAY: u32 = 0x1c;
 pub(crate) const WORD_LENGTH_32: u32 = 0x1;
 pub(crate) const HIGH_SPEED: u32 = 0x10;
+pub(crate) const INTERRUPT_HIGH: u32 = 1 << 5;
+pub(crate) const WAKE_UP: u32 = 1 << 7;
 
 // SPI_STATUS_REGISTER bits
 pub(crate) const STATUS_DATA_NOT_AVAILABLE: u32 = 0x00000001;

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,4 +1,5 @@
 #![allow(unused)]
+
 pub(crate) const FUNC_BUS: u32 = 0;
 pub(crate) const FUNC_BACKPLANE: u32 = 1;
 pub(crate) const FUNC_WLAN: u32 = 2;
@@ -103,3 +104,149 @@ pub(crate) const WRITE: bool = true;
 pub(crate) const READ: bool = false;
 pub(crate) const INC_ADDR: bool = true;
 pub(crate) const FIXED_ADDR: bool = false;
+
+#[allow(dead_code)]
+pub(crate) struct FormatStatus(pub u32);
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for FormatStatus {
+    fn format(&self, fmt: defmt::Formatter) {
+        macro_rules! implm {
+            ($($name:ident),*) => {
+                $(
+                    if self.0 & $name > 0 {
+                        defmt::write!(fmt, " | {}", &stringify!($name)[7..]);
+                    }
+                )*
+            };
+        }
+
+        implm!(
+            STATUS_DATA_NOT_AVAILABLE,
+            STATUS_UNDERFLOW,
+            STATUS_OVERFLOW,
+            STATUS_F2_INTR,
+            STATUS_F3_INTR,
+            STATUS_F2_RX_READY,
+            STATUS_F3_RX_READY,
+            STATUS_HOST_CMD_DATA_ERR,
+            STATUS_F2_PKT_AVAILABLE,
+            STATUS_F3_PKT_AVAILABLE
+        );
+    }
+}
+
+#[cfg(feature = "log")]
+impl core::fmt::Debug for FormatStatus {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+        macro_rules! implm {
+            ($($name:ident),*) => {
+                $(
+                    if self.0 & $name > 0 {
+                        core::write!(fmt, " | {}", &stringify!($name)[7..])?;
+                    }
+                )*
+            };
+        }
+
+        implm!(
+            STATUS_DATA_NOT_AVAILABLE,
+            STATUS_UNDERFLOW,
+            STATUS_OVERFLOW,
+            STATUS_F2_INTR,
+            STATUS_F3_INTR,
+            STATUS_F2_RX_READY,
+            STATUS_F3_RX_READY,
+            STATUS_HOST_CMD_DATA_ERR,
+            STATUS_F2_PKT_AVAILABLE,
+            STATUS_F3_PKT_AVAILABLE
+        );
+        Ok(())
+    }
+}
+
+#[cfg(feature = "log")]
+impl core::fmt::Display for FormatStatus {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(self, f)
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) struct FormatInterrupt(pub u16);
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for FormatInterrupt {
+    fn format(&self, fmt: defmt::Formatter) {
+        macro_rules! implm {
+            ($($name:ident),*) => {
+                $(
+                    if self.0 & $name > 0 {
+                        defmt::write!(fmt, " | {}", &stringify!($name)[4..]);
+                    }
+                )*
+            };
+        }
+
+        implm!(
+            IRQ_DATA_UNAVAILABLE,
+            IRQ_F2_F3_FIFO_RD_UNDERFLOW,
+            IRQ_F2_F3_FIFO_WR_OVERFLOW,
+            IRQ_COMMAND_ERROR,
+            IRQ_DATA_ERROR,
+            IRQ_F2_PACKET_AVAILABLE,
+            IRQ_F3_PACKET_AVAILABLE,
+            IRQ_F1_OVERFLOW,
+            IRQ_MISC_INTR0,
+            IRQ_MISC_INTR1,
+            IRQ_MISC_INTR2,
+            IRQ_MISC_INTR3,
+            IRQ_MISC_INTR4,
+            IRQ_F1_INTR,
+            IRQ_F2_INTR,
+            IRQ_F3_INTR
+        );
+    }
+}
+
+#[cfg(feature = "log")]
+impl core::fmt::Debug for FormatInterrupt {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+        macro_rules! implm {
+            ($($name:ident),*) => {
+                $(
+                    if self.0 & $name > 0 {
+                        core::write!(fmt, " | {}", &stringify!($name)[7..])?;
+                    }
+                )*
+            };
+        }
+
+        implm!(
+            IRQ_DATA_UNAVAILABLE,
+            IRQ_F2_F3_FIFO_RD_UNDERFLOW,
+            IRQ_F2_F3_FIFO_WR_OVERFLOW,
+            IRQ_COMMAND_ERROR,
+            IRQ_DATA_ERROR,
+            IRQ_F2_PACKET_AVAILABLE,
+            IRQ_F3_PACKET_AVAILABLE,
+            IRQ_F1_OVERFLOW,
+            IRQ_MISC_INTR0,
+            IRQ_MISC_INTR1,
+            IRQ_MISC_INTR2,
+            IRQ_MISC_INTR3,
+            IRQ_MISC_INTR4,
+            IRQ_F1_INTR,
+            IRQ_F2_INTR,
+            IRQ_F3_INTR
+        );
+        Ok(())
+    }
+}
+
+#[cfg(feature = "log")]
+impl core::fmt::Display for FormatInterrupt {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(self, f)
+    }
+}

--- a/src/ioctl.rs
+++ b/src/ioctl.rs
@@ -75,7 +75,6 @@ impl IoctlState {
     pub async fn wait_pending(&self) -> PendingIoctl {
         let pending = poll_fn(|cx| {
             if let IoctlStateInner::Pending(pending) = self.state.get() {
-                warn!("found pending ioctl");
                 Poll::Ready(pending)
             } else {
                 self.register_runner(cx.waker());
@@ -89,7 +88,6 @@ impl IoctlState {
     }
 
     pub async fn do_ioctl(&self, kind: IoctlType, cmd: u32, iface: u32, buf: &mut [u8]) -> usize {
-        warn!("doing ioctl");
         self.state
             .set(IoctlStateInner::Pending(PendingIoctl { buf, kind, cmd, iface }));
         self.wake_runner();
@@ -98,7 +96,6 @@ impl IoctlState {
 
     pub fn ioctl_done(&self, response: &[u8]) {
         if let IoctlStateInner::Sent { buf } = self.state.get() {
-            warn!("ioctl complete");
             // TODO fix this
             (unsafe { &mut *buf }[..response.len()]).copy_from_slice(response);
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,7 +1,6 @@
 use core::slice;
 
 use embassy_futures::select::{select3, Either3};
-use embassy_futures::yield_now;
 use embassy_net_driver_channel as ch;
 use embassy_sync::pubsub::PubSubBehavior;
 use embassy_time::{block_for, Duration, Timer};
@@ -304,7 +303,6 @@ where
 
     /// Wait for IRQ on F2 packet available
     async fn handle_irq(&mut self, buf: &mut [u32; 512]) {
-        self.bus.clear_event();
         // Receive stuff
         let irq = self.bus.read16(FUNC_BUS, REG_BUS_INTERRUPT).await;
         trace!("irq{}", FormatInterrupt(irq));
@@ -331,8 +329,6 @@ where
             } else {
                 break;
             }
-
-            yield_now().await;
         }
     }
 


### PR DESCRIPTION
(This PR now contains the final impl of IRQs)

This is now the last part. It plugs the hole in the new event loop with IRQs.

First, we add some more methods to new Bus trait to wait for events. Removing the HAL traits was a good idea here, I deleted a bunch of additional code at this point. The clear events method is unfortunate but the PIO requires that we reset its IRQ flags. 

Waiting for IRQs is relatively straight forward. After the write-read cycle, we wait for the IRQ pin (PIN_24, same as MISO/MOSI) to be high and then let the PIO interrupt the CPU. Of couse this requires that we make the necessary confinguration to enable F2 interrupts and cofigure interrupts to be high.

In our event loop, after an interrupt, we check the interrupt register and status register and then handle the event. 
We check the status register in a loop, until there are no more events, then we wait for the next event. 

Additionally, we check the status register after doing ioctls or sending packets, in case any events happend while we were busy dealing with that. 
