### PR TITLE
Rework Ioctls to an async state machine

### DIFF
--- a/src/control.rs
+++ b/src/control.rs
@@ -1,8 +1,6 @@
-use core::cell::Cell;
 use core::cmp::{max, min};
 
 use ch::driver::LinkState;
-use embassy_futures::yield_now;
 use embassy_net_driver_channel as ch;
 use embassy_time::{Duration, Timer};
 
@@ -10,21 +8,18 @@ pub use crate::bus::SpiBusCyw43;
 use crate::consts::*;
 use crate::events::{Event, EventQueue};
 use crate::fmt::Bytes;
+use crate::ioctl::{IoctlState, IoctlType};
 use crate::structs::*;
-use crate::{countries, IoctlState, IoctlType, PowerManagementMode};
+use crate::{countries, PowerManagementMode};
 
 pub struct Control<'a> {
     state_ch: ch::StateRunner<'a>,
     event_sub: &'a EventQueue,
-    ioctl_state: &'a Cell<IoctlState>,
+    ioctl_state: &'a IoctlState,
 }
 
 impl<'a> Control<'a> {
-    pub(crate) fn new(
-        state_ch: ch::StateRunner<'a>,
-        event_sub: &'a EventQueue,
-        ioctl_state: &'a Cell<IoctlState>,
-    ) -> Self {
+    pub(crate) fn new(state_ch: ch::StateRunner<'a>, event_sub: &'a EventQueue, ioctl_state: &'a IoctlState) -> Self {
         Self {
             state_ch,
             event_sub,
@@ -278,23 +273,8 @@ impl<'a> Control<'a> {
     }
 
     async fn ioctl(&mut self, kind: IoctlType, cmd: u32, iface: u32, buf: &mut [u8]) -> usize {
-        // TODO cancel ioctl on future drop.
-
-        while !matches!(self.ioctl_state.get(), IoctlState::Idle) {
-            yield_now().await;
-        }
-
-        self.ioctl_state.set(IoctlState::Pending { kind, cmd, iface, buf });
-
-        let resp_len = loop {
-            if let IoctlState::Done { resp_len } = self.ioctl_state.get() {
-                break resp_len;
-            }
-            yield_now().await;
-        };
-
-        self.ioctl_state.set(IoctlState::Idle);
-
+        self.ioctl_state.do_ioctl(kind, cmd, iface, buf).await;
+        let resp_len = self.ioctl_state.wait_complete().await;
         resp_len
     }
 }

--- a/src/control.rs
+++ b/src/control.rs
@@ -273,6 +273,8 @@ impl<'a> Control<'a> {
     }
 
     async fn ioctl(&mut self, kind: IoctlType, cmd: u32, iface: u32, buf: &mut [u8]) -> usize {
+        // TODO cancel ioctl on future drop.
+
         self.ioctl_state.do_ioctl(kind, cmd, iface, buf).await;
         let resp_len = self.ioctl_state.wait_complete().await;
         resp_len

--- a/src/ioctl.rs
+++ b/src/ioctl.rs
@@ -1,0 +1,111 @@
+use core::cell::{Cell, RefCell};
+use core::future::poll_fn;
+use core::task::{Poll, Waker};
+
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::blocking_mutex::Mutex;
+use embassy_sync::waitqueue::WakerRegistration;
+
+#[derive(Clone, Copy)]
+pub enum IoctlType {
+    Get = 0,
+    Set = 2,
+}
+
+#[derive(Clone, Copy)]
+pub struct PendingIoctl {
+    pub buf: *mut [u8],
+    pub kind: IoctlType,
+    pub cmd: u32,
+    pub iface: u32,
+}
+
+#[derive(Clone, Copy)]
+enum IoctlStateInner {
+    Pending(PendingIoctl),
+    Sent { buf: *mut [u8] },
+    Done { resp_len: usize },
+}
+
+pub struct IoctlState {
+    state: Cell<IoctlStateInner>,
+    wakers: Mutex<NoopRawMutex, RefCell<(WakerRegistration, WakerRegistration)>>,
+}
+
+impl IoctlState {
+    pub fn new() -> Self {
+        Self {
+            state: Cell::new(IoctlStateInner::Done { resp_len: 0 }),
+            wakers: Mutex::new(RefCell::default()),
+        }
+    }
+
+    fn wake_control(&self) {
+        self.wakers.lock(|f| {
+            f.borrow_mut().0.wake();
+        })
+    }
+
+    fn register_control(&self, waker: &Waker) {
+        self.wakers.lock(|f| f.borrow_mut().0.register(waker));
+    }
+
+    fn wake_runner(&self) {
+        self.wakers.lock(|f| {
+            f.borrow_mut().1.wake();
+        })
+    }
+
+    fn register_runner(&self, waker: &Waker) {
+        self.wakers.lock(|f| f.borrow_mut().1.register(waker));
+    }
+
+    pub async fn wait_complete(&self) -> usize {
+        poll_fn(|cx| {
+            if let IoctlStateInner::Done { resp_len } = self.state.get() {
+                Poll::Ready(resp_len)
+            } else {
+                self.register_control(cx.waker());
+                Poll::Pending
+            }
+        })
+        .await
+    }
+
+    pub async fn wait_pending(&self) -> PendingIoctl {
+        let pending = poll_fn(|cx| {
+            if let IoctlStateInner::Pending(pending) = self.state.get() {
+                warn!("found pending ioctl");
+                Poll::Ready(pending)
+            } else {
+                self.register_runner(cx.waker());
+                Poll::Pending
+            }
+        })
+        .await;
+
+        self.state.set(IoctlStateInner::Sent { buf: pending.buf });
+        pending
+    }
+
+    pub async fn do_ioctl(&self, kind: IoctlType, cmd: u32, iface: u32, buf: &mut [u8]) -> usize {
+        warn!("doing ioctl");
+        self.state
+            .set(IoctlStateInner::Pending(PendingIoctl { buf, kind, cmd, iface }));
+        self.wake_runner();
+        self.wait_complete().await
+    }
+
+    pub fn ioctl_done(&self, response: &[u8]) {
+        if let IoctlStateInner::Sent { buf } = self.state.get() {
+            warn!("ioctl complete");
+            // TODO fix this
+            (unsafe { &mut *buf }[..response.len()]).copy_from_slice(response);
+
+            self.state.set(IoctlStateInner::Done {
+                resp_len: response.len(),
+            });
+            self.wake_control();
+        }
+    }
+}


### PR DESCRIPTION
This commit reworks the event loops in the `Runner` to use async constructs. This isn't really an advantage on its own but preparation to use async IRQ. Therefore, it's necessary to remove the manual polling and move to async events.

The tx buffer is already async from embassy so this largely concerncs Ioctls.

Instead of polling for tx bytes, ioctls or events, when then use select() to check if anything is ready. Events are a placeholder that is always ready for now to be fixed by using IRQs.