### PR TITLE
cancel ioctl when future is dropped

### DIFF
--- a/src/ioctl.rs
+++ b/src/ioctl.rs
@@ -88,6 +88,10 @@ impl IoctlState {
         pending
     }
 
+    pub fn cancel_ioctl(&self) {
+        self.state.set(IoctlStateInner::Done { resp_len: 0 });
+    }
+
     pub async fn do_ioctl(&self, kind: IoctlType, cmd: u32, iface: u32, buf: &mut [u8]) -> usize {
         warn!("doing ioctl");
         self.state


### PR DESCRIPTION
Adds a simple scope guard to the `ioctl` function that cancels the ioctl when the future is dropped before completion.

This way, potentially dangling pointers are removed from the state machine as long as Drop runs.