### PR TITLE
use send status feature of cyw43 instead of manually checking status

### DIFF
--- a/examples/rpi-pico-w/src/main.rs
+++ b/examples/rpi-pico-w/src/main.rs
@@ -215,16 +215,26 @@ impl MySpi {
 }
 
 impl cyw43::SpiBusCyw43 for MySpi {
-    async fn cmd_write(&mut self, write: &[u32]) {
+    async fn cmd_write(&mut self, write: &[u32]) -> u32 {
         self.cs.set_low();
         self.write(write).await;
+
+        let mut status = 0;
+        self.read(slice::from_mut(&mut status)).await;
+
         self.cs.set_high();
+        status
     }
 
-    async fn cmd_read(&mut self, write: u32, read: &mut [u32]) {
+    async fn cmd_read(&mut self, write: u32, read: &mut [u32]) -> u32 {
         self.cs.set_low();
         self.write(slice::from_ref(&write)).await;
         self.read(read).await;
+
+        let mut status = 0;
+        self.read(slice::from_mut(&mut status)).await;
+
         self.cs.set_high();
+        status
     }
 }

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -16,6 +16,7 @@ pub(crate) const WORD_LENGTH_32: u32 = 0x1;
 pub(crate) const HIGH_SPEED: u32 = 0x10;
 pub(crate) const INTERRUPT_HIGH: u32 = 1 << 5;
 pub(crate) const WAKE_UP: u32 = 1 << 7;
+pub(crate) const STATUS_ENABLE: u32 = 0x10000;
 
 // SPI_STATUS_REGISTER bits
 pub(crate) const STATUS_DATA_NOT_AVAILABLE: u32 = 0x00000001;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -315,10 +315,7 @@ where
     /// Handle F2 events while status register is set
     async fn check_status(&mut self, buf: &mut [u32; 512]) {
         loop {
-            let mut status = 0xFFFF_FFFF;
-            while status == 0xFFFF_FFFF {
-                status = self.bus.read32(FUNC_BUS, REG_BUS_STATUS).await;
-            }
+            let status = self.bus.status();
             trace!("check status{}", FormatStatus(status));
 
             if status & STATUS_F2_PKT_AVAILABLE != 0 {


### PR DESCRIPTION
With this feature, we get the status register for free from other bus operations. 
This costs an extra word on every read. I was doing this anyway in the write to wait for completion.