### PR TITLE
Maximum pio speed

### DIFF
--- a/cyw43-pio/src/lib.rs
+++ b/cyw43-pio/src/lib.rs
@@ -43,6 +43,7 @@ where
             "set pindirs, 0 side 0"
             // these nops seem to be necessary for fast clkdiv
             "nop            side 1"
+            "nop            side 0"
             "nop            side 1"
             // read in y-1 bits
             "lp2:"
@@ -70,11 +71,10 @@ where
         sm.write_instr(relocated.origin() as usize, relocated.code());
 
         // theoretical maximum according to data sheet, 100Mhz Pio => 50Mhz SPI Freq
-        // does not work yet,
-        // sm.set_clkdiv(0x0140);
+        sm.set_clkdiv(0x0140);
 
         // same speed as pico-sdk, 62.5Mhz
-        sm.set_clkdiv(0x0200);
+        // sm.set_clkdiv(0x0200);
 
         // 32 Mhz
         // sm.set_clkdiv(0x03E8);

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -74,7 +74,7 @@ where
         // 32-bit word length, little endian (which is the default endianess).
         self.write32_swapped(
             REG_BUS_CTRL,
-            WORD_LENGTH_32 | HIGH_SPEED | INTERRUPT_HIGH | WAKE_UP | STATUS_ENABLE,
+            WORD_LENGTH_32 | HIGH_SPEED | INTERRUPT_HIGH | WAKE_UP | STATUS_ENABLE | INTERRUPT_WITH_STATUS,
         )
         .await;
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -16,7 +16,8 @@ pub(crate) const WORD_LENGTH_32: u32 = 0x1;
 pub(crate) const HIGH_SPEED: u32 = 0x10;
 pub(crate) const INTERRUPT_HIGH: u32 = 1 << 5;
 pub(crate) const WAKE_UP: u32 = 1 << 7;
-pub(crate) const STATUS_ENABLE: u32 = 0x10000;
+pub(crate) const STATUS_ENABLE: u32 = 1 << 16;
+pub(crate) const INTERRUPT_WITH_STATUS: u32 = 1 << 17;
 
 // SPI_STATUS_REGISTER bits
 pub(crate) const STATUS_DATA_NOT_AVAILABLE: u32 = 0x00000001;


### PR DESCRIPTION
👀 🚀 

It just seems to require some sort of delay at higher speeds. It also has to be a clock cycle, nop 1 does not work. 
It's worth noting that these changes are not backwards compatible. So if we wanted to have the speed configurable, we would need to ship multiple programs (or build it dynamically, i guess). We now spend three instructions on speed, so I guess there is an argument for lower speed to free of instruction memory. 

I'm also setting the INTERRUPT_WITH_STATUS flag here to be extra safe. I've been having some hangs, maybe there are cases where I miss some status updates. This setting should hopefully prevent this by sending extra interrupts.