### PR TITLE
clear DATA_UNAVAILABLE irq

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -310,6 +310,12 @@ where
         if irq & IRQ_F2_PACKET_AVAILABLE != 0 {
             self.check_status(buf).await;
         }
+
+        if irq & IRQ_DATA_UNAVAILABLE != 0 {
+            // TODO what should we do here?
+            warn!("IRQ DATA_UNAVAILABLE, clearing...");
+            self.bus.write16(FUNC_BUS, REG_BUS_INTERRUPT, 1).await;
+        }
     }
 
     /// Handle F2 events while status register is set


### PR DESCRIPTION
This seems to happen sometimes. Might be related to the firmware logs? I'm not sure. 

This bit has to manually cleared according to the data sheet, otherwise it just keeps showing up in every irq.