### PR TITLE
Wifi scanning part 1

### DIFF
--- a/examples/rpi-pico-w/src/main.rs
+++ b/examples/rpi-pico-w/src/main.rs
@@ -81,6 +81,8 @@ async fn main(spawner: Spawner) {
         .set_power_management(cyw43::PowerManagementMode::PowerSave)
         .await;
 
+    control.scan().await;
+
     let config = Config::Dhcp(Default::default());
     //let config = embassy_net::Config::Static(embassy_net::Config {
     //    address: Ipv4Cidr::new(Ipv4Address::new(192, 168, 69, 2), 24),

--- a/src/events.rs
+++ b/src/events.rs
@@ -3,7 +3,7 @@
 
 use core::num;
 
-use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_sync::pubsub::{PubSubChannel, Publisher, Subscriber};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, num_enum::FromPrimitive)]
@@ -284,9 +284,9 @@ pub enum Event {
     LAST = 190,
 }
 
-pub type EventQueue = PubSubChannel<CriticalSectionRawMutex, EventStatus, 2, 1, 1>;
-pub type EventPublisher<'a> = Publisher<'a, CriticalSectionRawMutex, EventStatus, 2, 1, 1>;
-pub type EventSubscriber<'a> = Subscriber<'a, CriticalSectionRawMutex, EventStatus, 2, 1, 1>;
+pub type EventQueue = PubSubChannel<NoopRawMutex, EventStatus, 2, 1, 1>;
+pub type EventPublisher<'a> = Publisher<'a, NoopRawMutex, EventStatus, 2, 1, 1>;
+pub type EventSubscriber<'a> = Subscriber<'a, NoopRawMutex, EventStatus, 2, 1, 1>;
 
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -251,3 +251,54 @@ impl EventMask {
         self.events[evt / 8] &= !(1 << (evt % 8));
     }
 }
+
+/// Parameters for a wifi scan
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(C)]
+pub struct ScanParams {
+    pub version: u32,
+    pub action: u16,
+    pub sync_id: u16,
+    pub ssid_len: u32,
+    pub ssid: [u8; 32],
+    pub bssid: [u8; 6],
+    pub bss_type: u8,
+    pub scan_type: u8,
+    pub nprobes: u32,
+    pub active_time: u32,
+    pub passive_time: u32,
+    pub home_time: u32,
+    pub channel_num: u32,
+    pub channel_list: [u16; 1],
+}
+impl_bytes!(ScanParams);
+
+/// Wifi Scan Results Header, followed by `bss_count` `BssInfo`
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(C)]
+pub struct ScanResults {
+    pub buflen: u32,
+    pub version: u32,
+    pub sync_id: u16,
+    pub bss_count: u16,
+}
+impl_bytes!(ScanResults);
+
+/// Wifi Scan Result
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(C)]
+#[non_exhaustive]
+pub struct BssInfo {
+    pub version: u32,
+    pub length: u32,
+    pub bssid: [u8; 6],
+    pub beacon_period: u16,
+    pub capability: u16,
+    pub ssid_len: u8,
+    pub ssid: [u8; 32],
+    // there will be more stuff here
+}
+impl_bytes!(BssInfo);


### PR DESCRIPTION
This implements the ioctl to start wifi scanning and events to receive scan results. Unfortunately, we don't have a nice way of communicating the results back to the control task. Found networks are thus just logged in the `Runner`.

We could put it through the event queue but some sort of shared memory solution would probably be nicer.

So for now, it just communicates the end of the scan through the event queue.

> 1.415246 INFO  set escan = [01, 00, 00, 00, 01, 00, 01, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, ff, ff, ff, ff, ff, ff, 02, 01, ff, ff, ff, ff, ff, ff, ff, ff, ff, ff, ff, ff, ff, ff, ff, ff, 00, 00, 00, 00, 00, 00, 00, 00]
> 1.416485 INFO  IOCTL Response: [65, 73, 63, 61, 6e, 00, 01, 00, 00, 00, 01, 00, 01, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, ff, ff, ff, ff, ff, ff, 02, 01, ff, ff, ff, ff, ff, ff, ff, ff, ff, ff, ff, ff, ff, ff, ff, ff, 00, 00, 00, 00, 00, 00, 00, 00]
> 1.444340 INFO  === Wifi Scan [x, x, x, x, x, x] == CensoredSSID1
> 1.704589 INFO  === Wifi Scan [y, y, y, y, y, y] == CensoredSSID2
> ....
> 3.000194 INFO  Wifi Scan done