### PR TITLE
rework event handling to allow sending data to `Control`

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -1,11 +1,10 @@
-use core::slice;
-
 use embassy_futures::yield_now;
 use embassy_time::{Duration, Timer};
 use embedded_hal_1::digital::OutputPin;
 use futures::FutureExt;
 
 use crate::consts::*;
+use crate::slice8_mut;
 
 /// Custom Spi Trait that _only_ supports the bus operation of the cyw43
 /// Implementors are expected to hold the CS pin low during an operation.
@@ -326,9 +325,4 @@ fn swap16(x: u32) -> u32 {
 
 fn cmd_word(write: bool, incr: bool, func: u32, addr: u32, len: u32) -> u32 {
     (write as u32) << 31 | (incr as u32) << 30 | (func & 0b11) << 28 | (addr & 0x1FFFF) << 11 | (len & 0x7FF)
-}
-
-fn slice8_mut(x: &mut [u32]) -> &mut [u8] {
-    let len = x.len() * 4;
-    unsafe { slice::from_raw_parts_mut(x.as_mut_ptr() as _, len) }
 }

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -109,6 +109,50 @@ pub(crate) const READ: bool = false;
 pub(crate) const INC_ADDR: bool = true;
 pub(crate) const FIXED_ADDR: bool = false;
 
+#[allow(non_camel_case_types)]
+#[derive(Copy, Clone)]
+#[repr(u8)]
+pub enum EStatus {
+    /// operation was successful
+    SUCCESS = 0,
+    /// operation failed
+    FAIL = 1,
+    /// operation timed out
+    TIMEOUT = 2,
+    /// failed due to no matching network found
+    NO_NETWORKS = 3,
+    /// operation was aborted
+    ABORT = 4,
+    /// protocol failure: packet not ack'd
+    NO_ACK = 5,
+    /// AUTH or ASSOC packet was unsolicited
+    UNSOLICITED = 6,
+    /// attempt to assoc to an auto auth configuration
+    ATTEMPT = 7,
+    /// scan results are incomplete
+    PARTIAL = 8,
+    /// scan aborted by another scan
+    NEWSCAN = 9,
+    /// scan aborted due to assoc in progress
+    NEWASSOC = 10,
+    /// 802.11h quiet period started
+    _11HQUIET = 11,
+    /// user disabled scanning (WLC_SET_SCANSUPPRESS)
+    SUPPRESS = 12,
+    /// no allowable channels to scan
+    NOCHANS = 13,
+    /// scan aborted due to CCX fast roam
+    CCXFASTRM = 14,
+    /// abort channel select
+    CS_ABORT = 15,
+}
+
+impl PartialEq<EStatus> for u32 {
+    fn eq(&self, other: &EStatus) -> bool {
+        *self == *other as Self
+    }
+}
+
 #[allow(dead_code)]
 pub(crate) struct FormatStatus(pub u32);
 

--- a/src/control.rs
+++ b/src/control.rs
@@ -6,7 +6,7 @@ use embassy_time::{Duration, Timer};
 
 pub use crate::bus::SpiBusCyw43;
 use crate::consts::*;
-use crate::events::{Event, EventQueue};
+use crate::events::{Event, Events};
 use crate::fmt::Bytes;
 use crate::ioctl::{IoctlState, IoctlType};
 use crate::structs::*;
@@ -14,15 +14,15 @@ use crate::{countries, PowerManagementMode};
 
 pub struct Control<'a> {
     state_ch: ch::StateRunner<'a>,
-    event_sub: &'a EventQueue,
+    events: &'a Events,
     ioctl_state: &'a IoctlState,
 }
 
 impl<'a> Control<'a> {
-    pub(crate) fn new(state_ch: ch::StateRunner<'a>, event_sub: &'a EventQueue, ioctl_state: &'a IoctlState) -> Self {
+    pub(crate) fn new(state_ch: ch::StateRunner<'a>, event_sub: &'a Events, ioctl_state: &'a IoctlState) -> Self {
         Self {
             state_ch,
-            event_sub,
+            events: event_sub,
             ioctl_state,
         }
     }
@@ -195,24 +195,25 @@ impl<'a> Control<'a> {
     }
 
     async fn wait_for_join(&mut self, i: SsidInfo) {
-        let mut subscriber = self.event_sub.subscriber().unwrap();
+        self.events.mask.enable(&[Event::JOIN, Event::AUTH]);
+        let mut subscriber = self.events.queue.subscriber().unwrap();
         self.ioctl(IoctlType::Set, IOCTL_CMD_SET_SSID, 0, &mut i.to_bytes())
             .await;
         // set_ssid
 
         loop {
             let msg = subscriber.next_message_pure().await;
-            if msg.event_type == Event::AUTH && msg.status != 0 {
+            if msg.header.event_type == Event::AUTH && msg.header.status != 0 {
                 // retry
-                warn!("JOIN failed with status={}", msg.status);
+                warn!("JOIN failed with status={}", msg.header.status);
                 self.ioctl(IoctlType::Set, IOCTL_CMD_SET_SSID, 0, &mut i.to_bytes())
                     .await;
-            } else if msg.event_type == Event::JOIN && msg.status == 0 {
+            } else if msg.header.event_type == Event::JOIN && msg.header.status == 0 {
                 // successful join
                 break;
             }
         }
-
+        self.events.mask.disable_all();
         self.state_ch.set_link_state(LinkState::Up);
         info!("JOINED");
     }

--- a/src/events.rs
+++ b/src/events.rs
@@ -331,34 +331,34 @@ impl Message {
     }
 }
 
-const EVENT_BITS: usize = ((Event::LAST as usize + 31) & !31) / 32;
-
 #[derive(Default)]
 struct EventMask {
-    mask: [u32; EVENT_BITS],
+    mask: [u32; Self::WORD_COUNT],
 }
 
 impl EventMask {
+    const WORD_COUNT: usize = ((Event::LAST as u32 + (u32::BITS - 1)) / u32::BITS) as usize;
+
     fn enable(&mut self, event: Event) {
         let n = event as u32;
-        let word = n >> 5;
-        let bit = n & 0b11111;
+        let word = n / u32::BITS;
+        let bit = n % u32::BITS;
 
         self.mask[word as usize] |= (1 << bit);
     }
 
     fn disable(&mut self, event: Event) {
         let n = event as u32;
-        let word = n >> 5;
-        let bit = n & 0b11111;
+        let word = n / u32::BITS;
+        let bit = n % u32::BITS;
 
         self.mask[word as usize] &= !(1 << bit);
     }
 
     fn is_enabled(&self, event: Event) -> bool {
         let n = event as u32;
-        let word = n >> 5;
-        let bit = n & 0b11111;
+        let word = n / u32::BITS;
+        let bit = n % u32::BITS;
 
         self.mask[word as usize] & (1 << bit) > 0
     }

--- a/src/ioctl.rs
+++ b/src/ioctl.rs
@@ -4,6 +4,8 @@ use core::task::{Poll, Waker};
 
 use embassy_sync::waitqueue::WakerRegistration;
 
+use crate::fmt::Bytes;
+
 #[derive(Clone, Copy)]
 pub enum IoctlType {
     Get = 0,
@@ -100,6 +102,8 @@ impl IoctlState {
 
     pub fn ioctl_done(&self, response: &[u8]) {
         if let IoctlStateInner::Sent { buf } = self.state.get() {
+            info!("IOCTL Response: {:02x}", Bytes(response));
+
             // TODO fix this
             (unsafe { &mut *buf }[..response.len()]).copy_from_slice(response);
 
@@ -107,6 +111,8 @@ impl IoctlState {
                 resp_len: response.len(),
             });
             self.wake_control();
+        } else {
+            warn!("IOCTL Response but no pending Ioctl");
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,11 @@ mod control;
 mod nvram;
 mod runner;
 
+use core::slice;
+
 use embassy_net_driver_channel as ch;
 use embedded_hal_1::digital::OutputPin;
-use events::EventQueue;
+use events::Events;
 use ioctl::IoctlState;
 
 use crate::bus::Bus;
@@ -103,7 +105,7 @@ const CHIP: Chip = Chip {
 pub struct State {
     ioctl_state: IoctlState,
     ch: ch::State<MTU, 4, 4>,
-    events: EventQueue,
+    events: Events,
 }
 
 impl State {
@@ -111,7 +113,7 @@ impl State {
         Self {
             ioctl_state: IoctlState::new(),
             ch: ch::State::new(),
-            events: EventQueue::new(),
+            events: Events::new(),
         }
     }
 }
@@ -224,4 +226,9 @@ where
         Control::new(state_ch, &state.events, &state.ioctl_state),
         runner,
     )
+}
+
+fn slice8_mut(x: &mut [u32]) -> &mut [u8] {
+    let len = x.len() * 4;
+    unsafe { slice::from_raw_parts_mut(x.as_mut_ptr() as _, len) }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -406,6 +406,10 @@ where
                     let status = event_packet.msg.status;
                     let event_payload = events::Payload::None;
 
+                    // this intentionally uses the non-blocking publish immediate
+                    // publish() is a deadlock risk in the current design as awaiting here prevents ioctls
+                    // The `Runner` always yields when accessing the device, so consumers always have a chance to receive the event
+                    // (if they are actively awaiting the queue)
                     self.events.queue.publish_immediate(events::Message::new(
                         Status {
                             event_type: evt_type,


### PR DESCRIPTION
This expands the event handling previously used for the join ioctls.

- Adds an enum for the event status field ([from here](https://github.com/Infineon/wifi-host-driver/blob/master/WiFi_Host_Driver/src/include/whd_events_int.h#L195))
- Adds an event publishing can be enabled and disabled by `Control`
- Adds Payload enum to carry event data. Currently empty. Will be used for wifi scanning.

