### PR TITLE
cyw43-pio optional feature for defmt

### DIFF
--- a/cyw43-pio/Cargo.toml
+++ b/cyw43-pio/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies]
 cyw43 = { path = "../" }
 embassy-rp = { version = "0.1.0",  features = ["unstable-traits", "nightly", "unstable-pac", "time-driver"] }
-# embassy-rp = { version = "0.1.0",  features = ["defmt", "unstable-traits", "nightly", "unstable-pac", "time-driver"] }
 pio-proc = "0.2"
 pio = "0.2.1"
-# defmt = "0.3"
+defmt = { version = "0.3", optional = true }

--- a/cyw43-pio/Cargo.toml
+++ b/cyw43-pio/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2021"
 
 [dependencies]
 cyw43 = { path = "../" }
-embassy-rp = { version = "0.1.0",  features = ["defmt", "unstable-traits", "nightly", "unstable-pac", "time-driver"] }
+embassy-rp = { version = "0.1.0",  features = ["unstable-traits", "nightly", "unstable-pac", "time-driver"] }
+# embassy-rp = { version = "0.1.0",  features = ["defmt", "unstable-traits", "nightly", "unstable-pac", "time-driver"] }
 pio-proc = "0.2"
 pio = "0.2.1"
-defmt = "0.3"
+# defmt = "0.3"

--- a/cyw43-pio/src/lib.rs
+++ b/cyw43-pio/src/lib.rs
@@ -129,7 +129,7 @@ where
         let write_bits = write.len() * 32 - 1;
         let read_bits = 31;
 
-        defmt::trace!("write={} read={}", write_bits, read_bits);
+        // defmt::trace!("write={} read={}", write_bits, read_bits);
 
         let mut dma = Peripheral::into_ref(&mut self.dma);
         pio_instr_util::set_x(&mut self.sm, write_bits as u32);
@@ -151,7 +151,7 @@ where
         let write_bits = 31;
         let read_bits = read.len() * 32 + 32 - 1;
 
-        defmt::trace!("write={} read={}", write_bits, read_bits);
+        // defmt::trace!("write={} read={}", write_bits, read_bits);
 
         let mut dma = Peripheral::into_ref(&mut self.dma);
         pio_instr_util::set_y(&mut self.sm, read_bits as u32);

--- a/cyw43-pio/src/lib.rs
+++ b/cyw43-pio/src/lib.rs
@@ -129,7 +129,8 @@ where
         let write_bits = write.len() * 32 - 1;
         let read_bits = 31;
 
-        // defmt::trace!("write={} read={}", write_bits, read_bits);
+        #[cfg(feature = "defmt")]
+        defmt::trace!("write={} read={}", write_bits, read_bits);
 
         let mut dma = Peripheral::into_ref(&mut self.dma);
         pio_instr_util::set_x(&mut self.sm, write_bits as u32);
@@ -151,7 +152,8 @@ where
         let write_bits = 31;
         let read_bits = read.len() * 32 + 32 - 1;
 
-        // defmt::trace!("write={} read={}", write_bits, read_bits);
+        #[cfg(feature = "defmt")]
+        defmt::trace!("write={} read={}", write_bits, read_bits);
 
         let mut dma = Peripheral::into_ref(&mut self.dma);
         pio_instr_util::set_y(&mut self.sm, read_bits as u32);

--- a/examples/rpi-pico-w/Cargo.toml
+++ b/examples/rpi-pico-w/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 cyw43 = { path = "../../", features = ["defmt", "firmware-logs"] }
-cyw43-pio = { path = "../../cyw43-pio" }
+cyw43-pio = { path = "../../cyw43-pio", features = ["defmt"] }
 embassy-executor = { version = "0.1.0",  features = ["defmt", "integrated-timers", "executor-thread", "arch-cortex-m"] }
 embassy-time = { version = "0.1.0",  features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-rp = { version = "0.1.0",  features = ["defmt", "unstable-traits", "nightly", "unstable-pac", "time-driver"] }


### PR DESCRIPTION
Adds an optional feature in cyw43-pio crate for defmt. The same feature flag is already used in the cyw43 crate. 