### PR TITLE
simple a simple Error type for join instead of looping internally

### DIFF
--- a/examples/rpi-pico-w/src/bin/tcp_server.rs
+++ b/examples/rpi-pico-w/src/bin/tcp_server.rs
@@ -94,8 +94,15 @@ async fn main(spawner: Spawner) {
 
     unwrap!(spawner.spawn(net_task(stack)));
 
-    //control.join_open(env!("WIFI_NETWORK")).await;
-    control.join_wpa2(env!("WIFI_NETWORK"), env!("WIFI_PASSWORD")).await;
+    loop {
+        //control.join_open(env!("WIFI_NETWORK")).await;
+        match control.join_wpa2(env!("WIFI_NETWORK"), env!("WIFI_PASSWORD")).await {
+            Ok(_) => break,
+            Err(err) => {
+                info!("join failed with status={}", err.status);
+            }
+        }
+    }
 
     // And now we can use it!
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ use ioctl::IoctlState;
 
 use crate::bus::Bus;
 pub use crate::bus::SpiBusCyw43;
-pub use crate::control::Control;
+pub use crate::control::{Control, Error as ControlError};
 pub use crate::runner::Runner;
 pub use crate::structs::BssInfo;
 


### PR DESCRIPTION
I originally put a loop in Control because the first join for me usually always timeouts when rebooting the pico.

But it's probably smart to just report errors to the application and let the user handle any errors.

I'm not sure what the smartest structure would be and which status code should actually be reported. 


A join op has a few events but always seems to end in a SET_SSID (not JOIN actually). 

I've seen SET_SSID with status 0=ok, 1=some went wrong with other events and 3=bad SSID so far...
I usually get AUTH with status 2=timeout

Funnily enough, a bad password results in a "successful" join, we probably want to do something more to catch that.

In the future, I may also want to extend this and also have errors for Ioctls. Getting these through the ioctl state machine shouldn't be too hard.