### PR TITLE
Fix PowerManagementMode::None

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,7 @@ impl PowerManagementMode {
     fn mode(&self) -> u32 {
         match self {
             PowerManagementMode::ThroughputThrottling => 1,
+            PowerManagementMode::None => 0,
             _ => 2,
         }
     }


### PR DESCRIPTION
Mode was being set to 2 (PM2_POWERSAVE_MODE), should be 0 (NO_POWERSAVE_MODE). 
Setting None mode failed with a panic:
```
85.707099 DEBUG set pm2_sleep_ret = [00, 00, 00, 00] 
└─ cyw43::control::{impl#0}::set_iovar_v::{async_fn#0} @ cyw43/src/fmt.rs:127 
85.710469 ERROR panicked at 'IOCTL error -29'
```